### PR TITLE
add text alignment + tests

### DIFF
--- a/packages/RichText-Core.package/RTEHeaderComponent.class/instance/highlightSelectedLevel.st
+++ b/packages/RichText-Core.package/RTEHeaderComponent.class/instance/highlightSelectedLevel.st
@@ -1,6 +1,0 @@
-styles
-highlightSelectedLevel
-
-	self menu submorphs do: [:button | 
-		button removeStyleClass: #success; changed].
-	(self menu findWidgetOfKind: PHButton labelled: (self level asString)) addStyleClass: #success

--- a/packages/RichText-Core.package/RTEHeaderComponent.class/instance/setLevel..st
+++ b/packages/RichText-Core.package/RTEHeaderComponent.class/instance/setLevel..st
@@ -1,6 +1,11 @@
 api
 setLevel: aSymbol
 
+	self level ifNotNilDo: [:level | 
+		(self menu findWidgetOfKind: PHButton labelled: level) 
+			removeStyleClass: #success; changed].
+
 	self level: aSymbol.
-	self highlightSelectedLevel.
-	self coreObject addApplicationStyles:(RTEHeaderComponent headerStyle at: aSymbol ifAbsent: (PHStyle forAny fontSize: 'xx-large'; fontWeight: 'bold'))
+	self coreObject addApplicationStyles:(RTEHeaderComponent headerStyle at: aSymbol ifAbsent: (PHStyle forAny fontSize: 'xx-large'; fontWeight: 'bold')).
+
+	(self menu findWidgetOfKind: PHButton labelled: (self level)) addStyleClass: #success; changed

--- a/packages/RichText-Core.package/RTEHeaderComponent.class/methodProperties.json
+++ b/packages/RichText-Core.package/RTEHeaderComponent.class/methodProperties.json
@@ -2,8 +2,7 @@
 	"class" : {
 		"headerStyle" : "AJ 5/20/2018 21:23" },
 	"instance" : {
-		"highlightSelectedLevel" : "AJ 5/29/2018 19:15",
 		"initialize" : "TH 5/22/2018 16:31",
 		"level" : "TH 5/17/2018 15:40",
 		"level:" : "TH 5/17/2018 15:40",
-		"setLevel:" : "AJ 5/29/2018 19:14" } }
+		"setLevel:" : "AJ 6/2/2018 15:23" } }

--- a/packages/RichText-Core.package/RTEHeaderComponentMenu.class/instance/initialize.st
+++ b/packages/RichText-Core.package/RTEHeaderComponentMenu.class/instance/initialize.st
@@ -4,7 +4,8 @@ initialize
 	super initialize.
 	1 to: 3 do: [:index|
 		self add: ((PHButton label: ('h',index))
-		when: #clicked 
-		send: #setLevel:
-		to: (self component)
-		with: ('h',index) asSymbol)]
+			when: #clicked 
+			send: #setLevel:
+			to: (self component)
+			with: ('h',index) asSymbol)
+		at: (1 + index)]

--- a/packages/RichText-Core.package/RTEHeaderComponentMenu.class/methodProperties.json
+++ b/packages/RichText-Core.package/RTEHeaderComponentMenu.class/methodProperties.json
@@ -2,4 +2,4 @@
 	"class" : {
 		 },
 	"instance" : {
-		"initialize" : "AJ 5/29/2018 19:17" } }
+		"initialize" : "AJ 6/2/2018 14:30" } }

--- a/packages/RichText-Core.package/RTETextComponent.class/instance/applyAlignment..st
+++ b/packages/RichText-Core.package/RTETextComponent.class/instance/applyAlignment..st
@@ -1,0 +1,9 @@
+initialization
+applyAlignment: anAlignmentSymbol
+
+
+	(self menu submorphNamed: 'align_',(self coreObject alignment asString)) removeStyleClass: #success; changed.
+
+	self coreObject alignment: anAlignmentSymbol.
+
+	(self menu submorphNamed: 'align_',(self coreObject alignment asString)) addStyleClass: #success; changed

--- a/packages/RichText-Core.package/RTETextComponent.class/methodProperties.json
+++ b/packages/RichText-Core.package/RTETextComponent.class/methodProperties.json
@@ -2,6 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
+		"applyAlignment:" : "AJ 6/2/2018 15:24",
 		"handleKeystroke:" : "AJ 5/29/2018 19:15",
 		"initialize" : "MB 5/17/2018 15:34",
 		"initializeMenu" : "AJ 5/24/2018 18:03",

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/instance/applyAlignment..st
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/instance/applyAlignment..st
@@ -1,0 +1,4 @@
+initialization
+applyAlignment: anAlignmentSymbol
+
+	self component coreObject alignment: anAlignmentSymbol

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/instance/applyAlignment..st
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/instance/applyAlignment..st
@@ -1,4 +1,4 @@
-initialization
+api
 applyAlignment: anAlignmentSymbol
 
 	self component coreObject alignment: anAlignmentSymbol

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/instance/applyAlignment..st
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/instance/applyAlignment..st
@@ -1,4 +1,0 @@
-api
-applyAlignment: anAlignmentSymbol
-
-	self component coreObject alignment: anAlignmentSymbol

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/instance/initialize.st
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/instance/initialize.st
@@ -1,4 +1,5 @@
 initialization
 initialize 
-	
-	super initialize
+
+	super initialize.
+	self initializeAlignmentButtons

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/instance/initializeAlignmentButtons.st
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/instance/initializeAlignmentButtons.st
@@ -1,0 +1,8 @@
+initialization
+initializeAlignmentButtons
+	
+	self
+		add: ((PHButton icon: #iconAlign_left)      name: 'align_left';      when: #clicked send: #applyAlignment: to: self with: #left);
+		add: ((PHButton icon: #iconAlign_center) name: 'align_center'; when: #clicked send: #applyAlignment: to: self with: #center);
+		add: ((PHButton icon: #iconAlign_right)   name: 'align_right';    when: #clicked send: #applyAlignment: to: self with: #right)";
+		add: ((PHButton icon: #iconAlign_justify) name: 'align_justify';   when: #clicked send: #applyAlignment: to: self with: #justify)"

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/instance/initializeAlignmentButtons.st
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/instance/initializeAlignmentButtons.st
@@ -1,8 +1,15 @@
 initialization
 initializeAlignmentButtons
 	
-	self
-		add: ((PHButton icon: #iconAlign_left)      name: 'align_left';      when: #clicked send: #applyAlignment: to: self with: #left);
-		add: ((PHButton icon: #iconAlign_center) name: 'align_center'; when: #clicked send: #applyAlignment: to: self with: #center);
-		add: ((PHButton icon: #iconAlign_right)   name: 'align_right';    when: #clicked send: #applyAlignment: to: self with: #right)";
-		add: ((PHButton icon: #iconAlign_justify) name: 'align_justify';   when: #clicked send: #applyAlignment: to: self with: #justify)"
+	| alignments |
+	
+	alignments := #(left center right justify).
+	alignments do: [:alignment |
+		self add: ((PHButton 
+			icon: (('iconAlign_',alignment)) asSymbol)
+		      name: 'align_',alignment;
+			when: #clicked 
+				send: #applyAlignment: 
+				to: (self component)
+				with: alignment)].
+	(self submorphNamed: 'align_left') addStyleClass: #success

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/instance/initializeAlignmentButtons.st
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/instance/initializeAlignmentButtons.st
@@ -1,10 +1,7 @@
 initialization
 initializeAlignmentButtons
 	
-	| alignments |
-	
-	alignments := #(left center right justify).
-	alignments do: [:alignment |
+	#(left center right" justify") do: [:alignment |
 		self add: ((PHButton 
 			icon: (('iconAlign_',alignment)) asSymbol)
 		      name: 'align_',alignment;

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/methodProperties.json
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/methodProperties.json
@@ -2,6 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"applyAlignment:" : "AJ 6/2/2018 14:11",
 		"initialize" : "AJ 6/2/2018 14:11",
-		"initializeAlignmentButtons" : "AJ 6/2/2018 14:29" } }
+		"initializeAlignmentButtons" : "AJ 6/2/2018 15:19" } }

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/methodProperties.json
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/methodProperties.json
@@ -3,4 +3,4 @@
 		 },
 	"instance" : {
 		"initialize" : "AJ 6/2/2018 14:11",
-		"initializeAlignmentButtons" : "AJ 6/2/2018 15:19" } }
+		"initializeAlignmentButtons" : "AJ 6/4/2018 17:19" } }

--- a/packages/RichText-Core.package/RTETextComponentMenu.class/methodProperties.json
+++ b/packages/RichText-Core.package/RTETextComponentMenu.class/methodProperties.json
@@ -2,4 +2,6 @@
 	"class" : {
 		 },
 	"instance" : {
-		"initialize" : "PUB 5/29/2018 17:12" } }
+		"applyAlignment:" : "AJ 6/2/2018 14:11",
+		"initialize" : "AJ 6/2/2018 14:11",
+		"initializeAlignmentButtons" : "AJ 6/2/2018 14:29" } }

--- a/packages/RichText-Tests.package/RTEComponentTest.class/instance/menuButtonByName..st
+++ b/packages/RichText-Tests.package/RTEComponentTest.class/instance/menuButtonByName..st
@@ -1,0 +1,4 @@
+accessing
+menuButtonByName: aName
+
+	^ self menu submorphNamed: aName

--- a/packages/RichText-Tests.package/RTEComponentTest.class/methodProperties.json
+++ b/packages/RichText-Tests.package/RTEComponentTest.class/methodProperties.json
@@ -8,6 +8,7 @@
 		"initialize:" : "AJ 5/29/2018 18:42",
 		"menu" : "AJ 5/29/2018 18:39",
 		"menuButton:" : "AJ 5/29/2018 18:43",
+		"menuButtonByName:" : "AJ 6/2/2018 14:36",
 		"menuDeleteButton" : "AJ 5/30/2018 18:43",
 		"setUp" : "AJ 5/30/2018 18:53",
 		"testDeleteComponent" : "AJ 5/30/2018 18:54" } }

--- a/packages/RichText-Tests.package/RTETextComponentTest.class/instance/testAlignmentApplied.st
+++ b/packages/RichText-Tests.package/RTETextComponentTest.class/instance/testAlignmentApplied.st
@@ -1,0 +1,16 @@
+testing
+testAlignmentApplied
+
+	self 
+		click: (self menuButtonByName: 'align_left');
+		assert: component coreObject alignment equals: #left;
+	
+		click: (self menuButtonByName: 'align_center');
+		assert: component coreObject alignment equals: #center;
+	
+		click: (self menuButtonByName: 'align_right');
+		assert: component coreObject alignment equals: #right";
+	
+		click: (self menuButtonByName: 'align_right');
+		assert: component coreObject alignment equals: #right
+		"

--- a/packages/RichText-Tests.package/RTETextComponentTest.class/instance/testAlignmentApplied.st
+++ b/packages/RichText-Tests.package/RTETextComponentTest.class/instance/testAlignmentApplied.st
@@ -9,7 +9,7 @@ testAlignmentApplied
 		assert: component coreObject alignment equals: #center;
 	
 		click: (self menuButtonByName: 'align_right');
-		assert: component coreObject alignment equals: #right;
+		assert: component coreObject alignment equals: #right";
 	
 		click: (self menuButtonByName: 'align_justify');
-		assert: component coreObject alignment equals: #justify
+		assert: component coreObject alignment equals: #justify"

--- a/packages/RichText-Tests.package/RTETextComponentTest.class/instance/testAlignmentApplied.st
+++ b/packages/RichText-Tests.package/RTETextComponentTest.class/instance/testAlignmentApplied.st
@@ -9,8 +9,7 @@ testAlignmentApplied
 		assert: component coreObject alignment equals: #center;
 	
 		click: (self menuButtonByName: 'align_right');
-		assert: component coreObject alignment equals: #right";
+		assert: component coreObject alignment equals: #right;
 	
-		click: (self menuButtonByName: 'align_right');
-		assert: component coreObject alignment equals: #right
-		"
+		click: (self menuButtonByName: 'align_justify');
+		assert: component coreObject alignment equals: #justify

--- a/packages/RichText-Tests.package/RTETextComponentTest.class/methodProperties.json
+++ b/packages/RichText-Tests.package/RTETextComponentTest.class/methodProperties.json
@@ -7,7 +7,7 @@
 		"selectTextByMouse" : "AJ 5/29/2018 19:09",
 		"setUp" : "AJ 5/29/2018 19:34",
 		"tearDown" : "AJ 5/29/2018 18:52",
-		"testAlignmentApplied" : "AJ 6/2/2018 14:43",
+		"testAlignmentApplied" : "AJ 6/2/2018 14:59",
 		"testPopoverAppearsByKeypress" : "AJ 5/29/2018 19:09",
 		"testPopoverAppearsByMouse" : "AJ 5/29/2018 19:09",
 		"testPopoverDisappearsOnApply" : "AJ 5/29/2018 19:09",

--- a/packages/RichText-Tests.package/RTETextComponentTest.class/methodProperties.json
+++ b/packages/RichText-Tests.package/RTETextComponentTest.class/methodProperties.json
@@ -7,7 +7,7 @@
 		"selectTextByMouse" : "AJ 5/29/2018 19:09",
 		"setUp" : "AJ 5/29/2018 19:34",
 		"tearDown" : "AJ 5/29/2018 18:52",
-		"testAlignmentApplied" : "AJ 6/2/2018 14:59",
+		"testAlignmentApplied" : "AJ 6/4/2018 17:19",
 		"testPopoverAppearsByKeypress" : "AJ 5/29/2018 19:09",
 		"testPopoverAppearsByMouse" : "AJ 5/29/2018 19:09",
 		"testPopoverDisappearsOnApply" : "AJ 5/29/2018 19:09",

--- a/packages/RichText-Tests.package/RTETextComponentTest.class/methodProperties.json
+++ b/packages/RichText-Tests.package/RTETextComponentTest.class/methodProperties.json
@@ -7,6 +7,7 @@
 		"selectTextByMouse" : "AJ 5/29/2018 19:09",
 		"setUp" : "AJ 5/29/2018 19:34",
 		"tearDown" : "AJ 5/29/2018 18:52",
+		"testAlignmentApplied" : "AJ 6/2/2018 14:43",
 		"testPopoverAppearsByKeypress" : "AJ 5/29/2018 19:09",
 		"testPopoverAppearsByMouse" : "AJ 5/29/2018 19:09",
 		"testPopoverDisappearsOnApply" : "AJ 5/29/2018 19:09",


### PR DESCRIPTION
# Ticket
https://github.com/hpi-swa-teaching/SWT18-Project-08/issues/46

# Description
It's now possible to align the text inside a text component to the left or center it.

# Is everything tested?
Jup, applied tests that are checking that Pheno got the alignment changes. Everything else is Phenos job and not ours.

# Is it release relevant?
Like in every good text editor, you can now change the alignment of the text you wrote. You can choose left, right and center.

# Screenshot
![image](https://user-images.githubusercontent.com/22987140/40876321-88f2e2f0-6679-11e8-8808-d7d0e7a84ff1.png)



# other checks
 - [x] no external ressources needed
 - [x] methods are formatted correctly
    - [x] no `.` at the end of your function
    - [x] functions have an empty line between functionname and code (except accessors)
    - [x] use cascades wherever possible
    - [x] variable definitions...
      - [x] ... have an space between before/after the `|` symbol
      - [x] ... have a blank line above and under
      - [x] ... are used as few as possible
   - [x] static values are stored on class Side
   - [x] every function has a category
 - [x] basic UX
   - [x] UI is intuitive to use (tested by the reviewer! reject if not)
   - [ ] ...
