### PR TITLE
diabled linux vm for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: smalltalk
 sudo: false
 
 os:
-  - linux
   - osx
 
 smalltalk:


### PR DESCRIPTION
Disabled linux vm for travis as it does not work with the ssl url we use to download our fonts.