### PR TITLE
#87 - prevent opening an editor two times

### DIFF
--- a/packages/RichText-Core.package/RichTextEditor.class/class/chooseDocument.st
+++ b/packages/RichText-Core.package/RichTextEditor.class/class/chooseDocument.st
@@ -1,11 +1,11 @@
 class initialization
 chooseDocument
 
-	| document documents selectionIndex |
-	
-	documents := self documents collect: [:entry | entry := entry title].
-	selectionIndex := (ListChooser chooseFrom: documents title: 'Documents').
+	| document selectionIndex |
+
+	selectionIndex := (ListChooser chooseFrom: (self documents collect: [:entry | entry := entry title]) title: 'Documents').
 	(selectionIndex > 0)
 	ifTrue: [
 		document := (self documents at: selectionIndex).
-		document openInWindowLabeled: (document title)]
+		document isInWorld
+			ifFalse: [document openInWindowLabeled: (document title)]]

--- a/packages/RichText-Core.package/RichTextEditor.class/instance/delete.st
+++ b/packages/RichText-Core.package/RichTextEditor.class/instance/delete.st
@@ -1,0 +1,5 @@
+accessing
+delete
+
+	self topLevel ifNotNilDo: [:topLevel | topLevel delete].
+	super delete

--- a/packages/RichText-Core.package/RichTextEditor.class/instance/deleteDocumentWithoutPrompt.st
+++ b/packages/RichText-Core.package/RichTextEditor.class/instance/deleteDocumentWithoutPrompt.st
@@ -6,4 +6,4 @@ deleteDocumentWithoutPrompt
 	allDocuments := self class documents.
 	allDocuments removeAllSuchThat: [:document | document == self].
 	self class documents: allDocuments.
-	self owner delete
+	self delete

--- a/packages/RichText-Core.package/RichTextEditor.class/methodProperties.json
+++ b/packages/RichText-Core.package/RichTextEditor.class/methodProperties.json
@@ -1,6 +1,6 @@
 {
 	"class" : {
-		"chooseDocument" : "AJ 6/14/2018 20:06",
+		"chooseDocument" : "AJ 6/28/2018 15:21",
 		"documents" : "AJ 6/14/2018 20:16",
 		"documents:" : "AJ 6/14/2018 18:01",
 		"initialize" : "AJ 5/31/2018 16:14",
@@ -13,8 +13,9 @@
 	"instance" : {
 		"coreObject" : "AJ 6/7/2018 15:48",
 		"coreObject:" : "AJ 6/7/2018 15:48",
+		"delete" : "AJ 6/28/2018 14:50",
 		"deleteDocument" : "AJ 6/24/2018 22:16",
-		"deleteDocumentWithoutPrompt" : "AJ 6/24/2018 22:41",
+		"deleteDocumentWithoutPrompt" : "AJ 6/28/2018 14:43",
 		"exportMarkdown" : "AJ 6/16/2018 15:04",
 		"exportMarkdownToClipboard" : "AJ 6/13/2018 21:55",
 		"initialize" : "AJ 6/21/2018 21:50",

--- a/packages/RichText-Core.package/RichTextEditorMenu.class/instance/chooseDocumentButton.st
+++ b/packages/RichText-Core.package/RichTextEditorMenu.class/instance/chooseDocumentButton.st
@@ -5,6 +5,5 @@ chooseDocumentButton
 		name: 'chooseDocument';
 		when: #clicked 
 		send: #chooseDocument
-		to: (self editor class)
-		withArguments: #();
+		to: (self editor class);
 		addTooltip: 'load another document')

--- a/packages/RichText-Core.package/RichTextEditorMenu.class/methodProperties.json
+++ b/packages/RichText-Core.package/RichTextEditorMenu.class/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		"newWith:" : "AJ 6/14/2018 19:20" },
 	"instance" : {
-		"chooseDocumentButton" : "AJ 6/14/2018 19:54",
+		"chooseDocumentButton" : "AJ 6/28/2018 15:04",
 		"deleteDocumentButton" : "AJ 6/14/2018 18:55",
 		"editor" : "AJ 6/13/2018 21:49",
 		"editor:" : "AJ 6/13/2018 21:49",


### PR DESCRIPTION
# Ticket
#87 

# Description
fixes the bug
 - when the window is already opened, no new window will be created
 - when you close a editor in any way, the complete window should close now

# Is everything tested?
nope :( Have to do this

# Is it release relevant?
nope

# Screenshot
nope

# coding style checks
 - [x] no external ressources needed
 - [x] coding standards 
    - [x] no `.` at the end of your function
    - [x] an empty line between functionname and code (except accessors)
    - [x] cascades wherever possible
    - [x] space around `@`, binary operators such as `+` or `<=` and after `^`
    - [x] no `or` stands alone in a line 
    - [x] variable definitions...
      - [x] ... have an space before/after the `|` symbol
      - [x] ... have a blank line above and under
      - [x] ... are used as few as possible   
   - [x] static values are stored on class Side
   - [x] every function has a category
   - [x] don't use magic numbers (and strings)!
 - [ ] basic UX
   - [ ] UI is intuitive to use (tested by the reviewer! reject if not)
   - [ ] ...

 ```smalltalk
example: aValue
   
   | variable |
   
   variable := 5.
   self myObject 
       value: aValue + variable;
       color: Color red.
   self otherMethod
   ```
