### PR TITLE
#82 min size image component

### DIFF
--- a/packages/RichText-Core.package/RTEImageComponent.class/instance/applyImageFrom..st
+++ b/packages/RichText-Core.package/RTEImageComponent.class/instance/applyImageFrom..st
@@ -3,5 +3,5 @@ applyImageFrom: aForm
 
 	self coreObject
 		form: aForm;
-		minSize: 50;
+		minSize: self defaultMinSize;
 		changed

--- a/packages/RichText-Core.package/RTEImageComponent.class/instance/applyImageFrom..st
+++ b/packages/RichText-Core.package/RTEImageComponent.class/instance/applyImageFrom..st
@@ -3,4 +3,5 @@ applyImageFrom: aForm
 
 	self coreObject
 		form: aForm;
+		minSize: 50;
 		changed

--- a/packages/RichText-Core.package/RTEImageComponent.class/instance/defaultMinSize.st
+++ b/packages/RichText-Core.package/RTEImageComponent.class/instance/defaultMinSize.st
@@ -1,0 +1,4 @@
+initialize
+defaultMinSize
+
+	^ 50

--- a/packages/RichText-Core.package/RTEImageComponent.class/methodProperties.json
+++ b/packages/RichText-Core.package/RTEImageComponent.class/methodProperties.json
@@ -2,8 +2,9 @@
 	"class" : {
 		 },
 	"instance" : {
-		"applyImageFrom:" : "KB 6/28/2018 15:27",
+		"applyImageFrom:" : "KB 6/28/2018 15:49",
 		"createMenu" : "AJ 6/21/2018 15:08",
+		"defaultMinSize" : "KB 6/28/2018 15:49",
 		"exportMarkdownOn:" : "AJ 6/26/2018 00:10",
 		"filename" : "AJ 6/7/2018 15:25",
 		"filename:" : "AJ 6/7/2018 15:25",

--- a/packages/RichText-Core.package/RTEImageComponent.class/methodProperties.json
+++ b/packages/RichText-Core.package/RTEImageComponent.class/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
-		"applyImageFrom:" : "AJ 6/21/2018 16:11",
+		"applyImageFrom:" : "KB 6/28/2018 15:27",
 		"createMenu" : "AJ 6/21/2018 15:08",
 		"exportMarkdownOn:" : "AJ 6/26/2018 00:10",
 		"filename" : "AJ 6/7/2018 15:25",

--- a/packages/RichText-Tests.package/RTEImageComponentTest.class/instance/testImageDisplayedWithMinSize.st
+++ b/packages/RichText-Tests.package/RTEImageComponentTest.class/instance/testImageDisplayedWithMinSize.st
@@ -1,0 +1,8 @@
+testing
+testImageDisplayedWithMinSize
+
+	component applyImageFrom: (Form makeStar).
+	self assert: component coreObject minSize notNil.
+	
+	component extent: 20@20.
+	self assert: (component coreObject minSize) equals: (component coreObject extent).

--- a/packages/RichText-Tests.package/RTEImageComponentTest.class/instance/testImageDisplayedWithMinSize.st
+++ b/packages/RichText-Tests.package/RTEImageComponentTest.class/instance/testImageDisplayedWithMinSize.st
@@ -5,4 +5,4 @@ testImageDisplayedWithMinSize
 	self assert: component coreObject minSize notNil.
 	
 	component extent: 20@20.
-	self assert: (component coreObject minSize) equals: (component coreObject extent).
+	self assert: (component coreObject minSize) equals: (component coreObject extent)

--- a/packages/RichText-Tests.package/RTEImageComponentTest.class/methodProperties.json
+++ b/packages/RichText-Tests.package/RTEImageComponentTest.class/methodProperties.json
@@ -8,7 +8,7 @@
 		"testApplySelectedImage" : "AJ 5/29/2018 19:10",
 		"testDisplayOnlyOneImage" : "AJ 6/21/2018 15:48",
 		"testExportMarkdown" : "AJ 6/7/2018 15:34",
-		"testImageDisplayedWithMinSize" : "KB 6/28/2018 15:38",
+		"testImageDisplayedWithMinSize" : "KB 6/28/2018 15:47",
 		"testMenuAlwaysVisibleWhenNoFileChosen" : "AJ 6/15/2018 13:45",
 		"testMenuReactsToFocusChangeWhenFileChosen" : "AJ 6/16/2018 14:47",
 		"testNoReactionWhenFilePickerClosed" : "AJ 6/19/2018 20:35",

--- a/packages/RichText-Tests.package/RTEImageComponentTest.class/methodProperties.json
+++ b/packages/RichText-Tests.package/RTEImageComponentTest.class/methodProperties.json
@@ -8,6 +8,7 @@
 		"testApplySelectedImage" : "AJ 5/29/2018 19:10",
 		"testDisplayOnlyOneImage" : "AJ 6/21/2018 15:48",
 		"testExportMarkdown" : "AJ 6/7/2018 15:34",
+		"testImageDisplayedWithMinSize" : "KB 6/28/2018 15:38",
 		"testMenuAlwaysVisibleWhenNoFileChosen" : "AJ 6/15/2018 13:45",
 		"testMenuReactsToFocusChangeWhenFileChosen" : "AJ 6/16/2018 14:47",
 		"testNoReactionWhenFilePickerClosed" : "AJ 6/19/2018 20:35",


### PR DESCRIPTION
# Ticket
https://github.com/hpi-swa-teaching/SWT18-Project-08/issues/82

# Description
Images now have a minSize, so that they are always visible at least with an extent of 50@50

# Is everything tested?
test asserts that the image extent will never be less than the minSize

# Is it release relevant?

# Screenshot
You have something cool to share? Add a screenshot to show how your new code should act.

# coding style checks
 - [ ] no external ressources needed
 - [x] coding standards 
    - [ ] no `.` at the end of your function
    - [ ] an empty line between functionname and code (except accessors)
    - [ ] cascades wherever possible
    - [ ] space around `@`, binary operators such as `+` or `<=` and after `^`
    - [ ] no `or` stands alone in a line 
    - [ ] variable definitions...
      - [ ] ... have an space before/after the `|` symbol
      - [ ] ... have a blank line above and under
      - [ ] ... are used as few as possible   
   - [ ] static values are stored on class Side
   - [ ] every function has a category
   - [ ] don't use magic numbers (and strings)!
 - [x] basic UX
   - [ ] UI is intuitive to use (tested by the reviewer! reject if not)
   - [ ] ...

 ```smalltalk
example: aValue
   
   | variable |
   
   variable := 5.
   self myObject 
       value: aValue + variable;
       color: Color red.
   self otherMethod
   ```
